### PR TITLE
Refactor forecast serializer

### DIFF
--- a/app/poros/forecast.rb
+++ b/app/poros/forecast.rb
@@ -5,6 +5,32 @@ class Forecast
     @location = location
   end
 
+  def time_zone
+    'UTC'
+  end
+
+  def location
+    google_return.address
+  end
+
+  def currently
+    Current.info(raw_forecast_data[:currently])
+  end
+
+  def today
+    Today.info(raw_forecast_data)
+  end
+
+  def hourly
+    Hourly.info(raw_forecast_data)
+  end
+
+  def daily
+    Daily.info(raw_forecast_data)
+  end
+
+  private
+
   def google_return
     GoogleGeoService.new(@location)
   end
@@ -17,30 +43,30 @@ class Forecast
     DarkSkyService.new(coordinates).parsed_forecast
   end
 
-  def forecast_data
-    {
-      time_zone: 'UTC',
-      location: google_return.address,
-      currently: current_data,
-      today: today_data,
-      hourly: hourly_data,
-      daily: daily_data
-    }
-  end
+  # def forecast_data
+  #   {
+  #     time_zone: 'UTC',
+  #     location: google_return.address,
+  #     currently: current_data,
+  #     today: today_data,
+  #     hourly: hourly_data,
+  #     daily: daily_data
+  #   }
+  # end
 
-  def current_data
-    Current.info(raw_forecast_data[:currently])
-  end
+  # def current_data
+  #   Current.info(raw_forecast_data[:currently])
+  # end
 
-  def today_data
-    Today.info(raw_forecast_data)
-  end
+  # def today_data
+  #   Today.info(raw_forecast_data)
+  # end
 
-  def hourly_data
-    Hourly.info(raw_forecast_data)
-  end
+  # def hourly_data
+  #   Hourly.info(raw_forecast_data)
+  # end
 
-  def daily_data
-    Daily.info(raw_forecast_data)
-  end
+  # def daily_data
+  #   Daily.info(raw_forecast_data)
+  # end
 end

--- a/app/poros/road_trip.rb
+++ b/app/poros/road_trip.rb
@@ -23,7 +23,7 @@ class RoadTrip
   end
 
   def arrival_temp
-    x = get_future_weather[:currently][:temperature]
+    get_future_weather[:currently][:temperature]
   end
 
   def arrival_summary

--- a/app/serializers/forecast_serializer.rb
+++ b/app/serializers/forecast_serializer.rb
@@ -1,4 +1,6 @@
 class ForecastSerializer
   include FastJsonapi::ObjectSerializer
-  attributes :forecast_data
+  
+  attributes :time_zone, :location, :currently,
+             :today, :hourly, :daily
 end

--- a/spec/requests/dark_sky/user_can_get_data_from_dark_sky_spec.rb
+++ b/spec/requests/dark_sky/user_can_get_data_from_dark_sky_spec.rb
@@ -1,24 +1,42 @@
 require 'rails_helper'
 
 RSpec.describe 'Dark Sky API' do
-  it 'can take a lat and long and get needed forecast data' do
+  # it 'can take a lat and long and get needed forecast data' do
+  #   location = 'denver,co'
+  #   get "/api/v1/forecast?location=#{location}"
+
+  #   expect(response).to be_successful
+
+  #   forecast = JSON.parse(response.body, symbolize_names: true)[:data][:attributes][:forecast_data]
+
+  #   expect(forecast.keys).to eq([:time_zone, :location, :currently, :today, :hourly, :daily])
+    
+  #   expect(forecast[:currently].keys).to eq([:time, :summary, :icon, :temp, :feels_like, :humidity, :visibility, :uv_index])
+
+  #   expect(forecast[:location]). to eq('Denver, CO, USA')
+
+  #   expect(forecast[:hourly].count).to eq(8)
+  #   expect(forecast[:hourly][0].keys).to eq([:time, :temp, :icon])
+
+  #   expect(forecast[:daily].count).to eq(5)
+  #   expect(forecast[:daily][0].keys).to eq([:summary, :icon, :precip_percent, :precip_type, :high, :low, :day])
+  # end
+
+  it 'can get refactored weather data' do
     location = 'denver,co'
     get "/api/v1/forecast?location=#{location}"
 
     expect(response).to be_successful
 
-    forecast = JSON.parse(response.body, symbolize_names: true)[:data][:attributes][:forecast_data]
+    forecast_data = JSON.parse(response.body, symbolize_names: true)[:data]
 
-    expect(forecast.keys).to eq([:time_zone, :location, :currently, :today, :hourly, :daily])
+    expect(forecast_data[:attributes].keys).to eq([:time_zone, :location, :currently, :today, :hourly, :daily])
     
-    expect(forecast[:currently].keys).to eq([:time, :summary, :icon, :temp, :feels_like, :humidity, :visibility, :uv_index])
-
-    expect(forecast[:location]). to eq('Denver, CO, USA')
-
-    expect(forecast[:hourly].count).to eq(8)
-    expect(forecast[:hourly][0].keys).to eq([:time, :temp, :icon])
-
-    expect(forecast[:daily].count).to eq(5)
-    expect(forecast[:daily][0].keys).to eq([:summary, :icon, :precip_percent, :precip_type, :high, :low, :day])
+    expect(forecast_data[:attributes][:time_zone]).to eq('UTC')
+    expect(forecast_data[:attributes][:location]).to eq('Denver, CO, USA')
+    expect(forecast_data[:attributes][:currently].keys).to eq([:time, :summary, :icon, :temp, :feels_like, :humidity, :visibility, :uv_index])
+    expect(forecast_data[:attributes][:today].keys).to eq([:date, :day_summary, :low, :high, :night_summary])
+    expect(forecast_data[:attributes][:hourly].count).to eq(8)
+    expect(forecast_data[:attributes][:daily].count).to eq(5)
   end
 end


### PR DESCRIPTION
- Clean up forecast PORO
- Give serializer multiple attributes rather than one big attribute with nested hashes
